### PR TITLE
Adding helper fn for java.util.Date interval and plus/minus.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/
+toolbelt-date.iml

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
-                 [clj-time "0.14.2"]]
+                 [clj-time "0.14.2"]
+                 [org.clojure/test.check "0.9.0"]]
   :deploy-repositories [["releases" {:url   "https://clojars.org/repo"
                                      :creds :gpg}]])

--- a/src/toolbelt/date.clj
+++ b/src/toolbelt/date.clj
@@ -135,18 +135,36 @@
        (end-of-day tz))))
 
 
-(defn plus-n-days
-  "Returns a java.util.Date that's 'n' days after the given java.util.Date.
-  If only providing 'n', will return a java.util.Date that's 'n' days after today."
-  ([n]
-   (plus-n-days (c/to-date (t/today)) n))
-  ([d n]
-   (-> d
-       (c/to-date-time)
-       (t/plus (t/days n))
-       (c/to-date))))
+(defn- transform*
+  [d f]
+  (-> d
+      c/to-date-time
+      (f)
+      c/to-date))
+
+
+(defn plus
+  "Returns a new java.util.Date corresponding to the given date (could be a long,
+  date/time, or java.util.Date) moved forwards by the given Period(s).
+  Using System/currentTimeMillis if no d is provided."
+  ([p]
+    (plus (System/currentTimeMillis) p))
+  ([d p]
+   (transform* d #(t/plus % p))))
+
+
+(defn minus
+  "Returns a new java.util.Date corresponding to the given date (could be a long,
+  date/time, or java.util.Date) moved backwards by the given Period(s).
+  Using System/currentTimeMillis if no d is provided."
+  ([p]
+   (plus (System/currentTimeMillis) p))
+  ([d p]
+   (transform* d #(t/minus % p))))
 
 
 (defn interval
+  "Returns an interval representing the span between the two given java.util.Date.
+  Note that intervals are closed on the left and open on the right."
   [d1 d2]
   (t/interval (c/to-date-time d1) (c/to-date-time d2)))

--- a/src/toolbelt/date.clj
+++ b/src/toolbelt/date.clj
@@ -133,3 +133,20 @@
        c/from-date
        t/last-day-of-the-month
        (end-of-day tz))))
+
+
+(defn plus-n-days
+  "Returns a java.util.Date that's 'n' days after the given java.util.Date.
+  If only providing 'n', will return a java.util.Date that's 'n' days after today."
+  ([n]
+   (plus-n-days (c/to-date (t/today)) n))
+  ([d n]
+   (-> d
+       (c/to-date-time)
+       (t/plus (t/days n))
+       (c/to-date))))
+
+
+(defn interval
+  [d1 d2]
+  (t/interval (c/to-date-time d1) (c/to-date-time d2)))

--- a/src/toolbelt/date.clj
+++ b/src/toolbelt/date.clj
@@ -165,6 +165,6 @@
 
 (defn interval
   "Returns an interval representing the span between the two given java.util.Date.
-  Note that intervals are closed on the left and open on the right."
-  [d1 d2]
-  (t/interval (c/to-date-time d1) (c/to-date-time d2)))
+  Note that intervals are closed on the left and open on the right, and from < to."
+  [from to]
+  (t/interval (c/to-date-time from) (c/to-date-time to)))

--- a/test/toolbelt/date_test.clj
+++ b/test/toolbelt/date_test.clj
@@ -84,10 +84,10 @@
 (defspec date-plus-minus-test
   100
   (prop/for-all
-    [year (gen/double* {:min 1 :max 3000 :NaN? false})
+    [year  (gen/double* {:min 1 :max 3000 :NaN? false})
      month (gen/double* {:min 1 :max 12 :NaN? false})
-     p gen/pos-int]
-    (let [inst   (c/to-date (t/date-time (int year) (int month)))]
+     p     gen/pos-int]
+    (let [inst (c/to-date (t/date-time (int year) (int month)))]
       (testing "The inst plus a period is always equal that inst minus the same period."
         (are [inst2] (= inst inst2)
                      (-> (date/plus inst (t/seconds p))

--- a/test/toolbelt/date_test.clj
+++ b/test/toolbelt/date_test.clj
@@ -1,7 +1,12 @@
 (ns toolbelt.date-test
-  (:require [clojure.test :refer :all]
-            [toolbelt.date :as date]
-            [clj-time.core :as t]))
+  (:require
+    [clj-time.core :as t]
+    [clojure.test.check.clojure-test :refer [defspec]]
+    [clojure.test.check.properties :as prop]
+    [clojure.test.check.generators :as gen]
+    [clojure.test :refer :all]
+    [toolbelt.date :as date]
+    [clj-time.coerce :as c]))
 
 (deftest short-test
   (is (= "3/15/89" (date/short #inst "1989-03-15")))
@@ -74,3 +79,28 @@
          #inst "2018-01-31T23:59:59.000-00:00"))
   (is (= (date/end-of-month #inst "2018-01-31T23:59:59.000-00:00" tz)
          #inst "2018-02-01T07:59:59.000-00:00")))
+
+
+(defspec date-plus-minus-test
+  100
+  (prop/for-all
+    [year (gen/double* {:min 1 :max 3000 :NaN? false})
+     month (gen/double* {:min 1 :max 12 :NaN? false})
+     p gen/pos-int]
+    (let [inst   (c/to-date (t/date-time (int year) (int month)))]
+      (testing "The inst plus a period is always equal that inst minus the same period."
+        (are [inst2] (= inst inst2)
+                     (-> (date/plus inst (t/seconds p))
+                         (date/minus (t/seconds p)))
+                     (-> (date/plus inst (t/minutes p))
+                         (date/minus (t/minutes p)))
+                     (-> (date/plus inst (t/hours p))
+                         (date/minus (t/hours p)))
+                     (-> (date/plus inst (t/days p))
+                         (date/minus (t/days p)))
+                     (-> (date/plus inst (t/weeks p))
+                         (date/minus (t/weeks p)))
+                     (-> (date/plus inst (t/months p))
+                         (date/minus (t/months p)))
+                     (-> (date/plus inst (t/years p))
+                         (date/minus (t/years p))))))))


### PR DESCRIPTION
## Context 
Since our preferred date class to use across the code base `java.util.Date`, I added helper functions for plus/minus to a date and creating intervals. This is to not have to transform back and forth between `org.joda.DateTime` and `java.util.Date`.

## Changes
- Adding functions for plus/minus, accepts any input (e.g. timestamp long, DateTime or java.util.Date).
- Added property based test for plus/minus in the form of `A+B - B = A` to verify functionality.
- Added interval that accepts any date input.

## Testing
`lein test` ✓
```
lein test toolbelt.date-test
{:result true, :num-tests 100, :seed 1535479603764, :test-var "date-plus-minus-test"}

Ran 10 tests containing 725 assertions.
0 failures, 0 errors.
```