### PR TITLE
[idea] Proposed patterns for toolbelt-date

### DIFF
--- a/src/toolbelt/date.clj
+++ b/src/toolbelt/date.clj
@@ -182,6 +182,19 @@
   (t/interval (c/to-date-time from) (c/to-date-time to)))
 
 
+(defn within?
+  "With 2 arguments: Returns true if the given Interval contains the given
+   date. Note that if the date is exactly equal to the
+   end of the interval, this function returns false.
+   With 3 arguments: Returns true if the start date is
+   equal to or before and the end date is equal to or after the test
+   ReadablePartial."
+  ([interval test]
+   (t/within? interval (c/to-date-time test)))
+  ([start end test]
+   (apply t/within? (map c/to-date-time [start end test]))))
+
+
 ;; =============================================================================
 ;; Components
 ;; =============================================================================

--- a/test/toolbelt/date_test.clj
+++ b/test/toolbelt/date_test.clj
@@ -84,23 +84,20 @@
 (defspec date-plus-minus-test
   100
   (prop/for-all
-    [year  (gen/double* {:min 1 :max 3000 :NaN? false})
+    [year (gen/double* {:min 1 :max 3000 :NaN? false})
      month (gen/double* {:min 1 :max 12 :NaN? false})
-     p     gen/pos-int]
-    (let [inst (c/to-date (t/date-time (int year) (int month)))]
+     p gen/pos-int]
+    (let [date-time (t/date-time (int year) (int month))
+          inst      (c/to-date date-time)
+          days      (t/days p)]
       (testing "The inst plus a period is always equal that inst minus the same period."
-        (are [inst2] (= inst inst2)
-                     (-> (date/plus inst (t/seconds p))
-                         (date/minus (t/seconds p)))
-                     (-> (date/plus inst (t/minutes p))
-                         (date/minus (t/minutes p)))
-                     (-> (date/plus inst (t/hours p))
-                         (date/minus (t/hours p)))
-                     (-> (date/plus inst (t/days p))
-                         (date/minus (t/days p)))
-                     (-> (date/plus inst (t/weeks p))
-                         (date/minus (t/weeks p)))
-                     (-> (date/plus inst (t/months p))
-                         (date/minus (t/months p)))
-                     (-> (date/plus inst (t/years p))
-                         (date/minus (t/years p))))))))
+        (are [d2] (= inst d2)
+          ;; org.joda.DateTime
+          (-> (date/plus date-time days)
+              (date/minus days))
+          ;; java.util.Date
+          (-> (date/plus inst days)
+              (date/minus days))
+          ;; Long (unix time)
+          (-> (date/plus (c/to-long date-time) days)
+              (date/minus days)))))))


### PR DESCRIPTION
## Background
This is some initial work towards making toolbelt-date an all mighty date library, with the goal of eliminating references to external date libraries anywhere in our system. Some code has been added, but as described under 'Changes', I'm considering another approach so this is more of an idea outline.

Asana: [Streamline the use of dates in our code base](https://app.asana.com/0/280474111880721/799975247798888)

From the Asana task:
> We're currently doing a lot of on-the-fly date math, back and forth to Joda Time and Java Date. This is not ideal as working with dates is very prone to errors. 
>
> I propose we work towards removing all use of clj-time across our code base, and isolate that to only be allowed in our toolbelt-date library.
>
> Ideally, toolbelt-date would also have cljs functionality so we can make sure we're doing the same thing on the client and server (I've been bitten previously by Java and JS dates being different.)
>
> Benefits:
> - Single point of failure, easier to fix potential date errors as they'd be isolated to one place.
> - More consistent in that we don't need to transform dates back and forth everywhere, and the library handles the everything we need date related.
> - Migrating from clj-time would be easier, as we'd need to update external libraries only in one place. (See [Move from Joda Time to Java Time](https://app.asana.com/0/280474111880721/799975247798889) for more info).

## Changes
In this PR I'm adding some utility functions in a similar pattern that `clj-time` has. However, I'm debating whether this is the best way to go and I'm leaning towards _**it's not**_.  Looking at [java-time](https://github.com/dm3/clojure.java-time) they have some interesting ways of using data to specify how to manipulate or adjust a date, while `clj-time` has an approach of one function for one thing and I think the way they go about it in `java-time` might be a better approach. 

## Idea
Would love your thoughts/input on this!

### Generic
These are some ideas taken from `java-time`, and the fact that I'm not a fan of `clj-time` and how there's just so many functions to keep track of (and they're not always compatible with each other even, e.g. `(t/interval (t/yesterday) (t/today))` will throw a `ClassCastException`). Instead of having functions for every separate thing, we could approach it in a different way similar to what they do in java-time:

```clojure
;; Adjusting dates 
;; Given a date instance of any type, return a new date adjusted to 1) first day of the month of <date>, 2) last day of the month of <date>
;; This is the clj-time style
(first-day-of-month <date>)
(last-day-of-month <date>)
;; and all other fns...

; Proposed: We could have one fn doing the things we need
(adjust <date> :first-in-month)
(adjust <date> :last-in-month)
;; Extensible to e.g.
(adjust <date> :first-in-month :noon)


;; Periods 
;; Given a number, returns a Period representing that many days/months.
;; This is the clj-time style
(days <n>)
(months <n>)
;; and all other fns...

; Proposed: In the same way as above, one fn for all that we need
(period :days  <n>)
(period :months <n>)
;; Extensible to e.g.
(period :months <n1> :days <n2>)
```

I feel the second approach is clearer and more flexible. As suggested above we could accept several arguments to do more things. E.g. consider these examples:
```clojure
;;Adjustments 
;; This is the clj-time style
(-> (first-day-of-month <date>)
    beginning-of-day)

;; VS proposed
(adjust <date> :first-in-month :beginning-of-day)


;; Math
;; This is the clj-time style
(-> (plus <date> (months 1))
    (plus (days 2)))

;; VS proposed 
(plus <date> (period :months 1 :days 2))
```

### Starcity specific
In addition to these generic things, I'm also thinking that we'd add functionality that's specific for our use case (e.g. date math related to license transitions and rent payments). That way we don't have to do custom math across our applications and when we experience date related bugs we'll know where to look for them.