### PR TITLE
add intervals of time

### DIFF
--- a/src/toolbelt/date.clj
+++ b/src/toolbelt/date.clj
@@ -201,6 +201,24 @@
   (t/in-days p))
 
 
+(defn seconds
+  "Given a number, returns a Period representing that many seconds."
+  [n]
+  (t/seconds n))
+
+
+(defn minutes
+  "Given a number, returns a Period representing that many minutes."
+  [n]
+  (t/minutes n))
+
+
+(defn hours
+  "Given a number, returns a Period representing that many hours."
+  [n]
+  (t/hours n))
+
+
 (defn days
   "Given a number, returns a Period representing that many days."
   [n]


### PR DESCRIPTION
## Context
add time intervals so I can use them to help get a tighter range when querying for payments.
Needed just seconds, but added the other ones.