### PR TITLE
Add min/max function for dates, change repositories to our own starjars.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,14 @@
   :description "Utilities for working with dates in Clojure/Script."
   :url "https://github.com/starcity-properties/toolbelt-date"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [clj-time "0.14.2"]
                  [org.clojure/test.check "0.9.0"]]
-  :deploy-repositories [["releases" {:url   "https://clojars.org/repo"
-                                     :creds :gpg}]])
+  :plugins [[s3-wagon-private "1.2.0"]]
+  :repositories {"releases"  {:url        "s3://starjars/releases"
+                              :username   :env/aws_access_key
+                              :passphrase :env/aws_secret_key}
+                 "snapshots" {:url        "s3://starjars/snapshots"
+                              :username   :env/aws_access_key
+                              :passphrase :env/aws_secret_key}})

--- a/src/toolbelt/date.clj
+++ b/src/toolbelt/date.clj
@@ -1,5 +1,5 @@
 (ns toolbelt.date
-  (:refer-clojure :exclude [short > < <= >=])
+  (:refer-clojure :exclude [short > < <= >= min max])
   (:require [clj-time.core :as t]
             [clj-time.format :as f]
             [clj-time.coerce :as c]
@@ -53,6 +53,12 @@
 ;; =============================================================================
 ;; Transformations
 ;; =============================================================================
+
+
+(defn- norm-out*
+  "Normalize the returned date value to a java.util.Date."
+  [date]
+  (c/to-date date))
 
 
 (defn transform
@@ -169,7 +175,7 @@
 
   'date' is a date instance as per 'toolbelt.date/transform'."
   ([period]
-   (plus (System/currentTimeMillis) period))
+   (minus (System/currentTimeMillis) period))
   ([date period]
    (transform date t/minus period)))
 
@@ -317,6 +323,18 @@
   date/time etc.)"
   [date & more]
   (apply compare* clojure.core/>= date more))
+
+
+(defn max
+  "Returns the largest date, i.e. the latest in time."
+  [date & more]
+  (norm-out* (apply clojure.core/max (map c/to-long (cons date more)))))
+
+
+(defn min
+  "Returns the smallest date, i.e. the earliest in time."
+  [date & more]
+  (norm-out* (apply clojure.core/min (map c/to-long (cons date more)))))
 
 
 ;; =============================================================================

--- a/test/toolbelt/date_test.clj
+++ b/test/toolbelt/date_test.clj
@@ -108,10 +108,12 @@
 
 
 (defspec date-plus-minus-test
+  ;; Run test 100 times with different generated data
   100
   (prop/for-all
+    ;; Generate random date and integer to represent number of days
     [inst (gen-date*)
-     p gen/pos-int]
+     p gen/int]
     (let [date-time (c/to-date-time inst)
           days      (t/days p)]
       (testing "The inst plus a period is always equal that inst minus the same period."
@@ -128,8 +130,10 @@
 
 
 (defspec date-min-max-test
+  ;; Run test 100 times with different generated data
   100
   (prop/for-all
+    ;; Generate a vector of dates with 1 to 100 elements
     [dts (gen/vector (gen-date*) 1 100)]
     (testing "Min date is always the earliest and max date is always the latest."
       (let [sorted-dates (sort dts)]

--- a/test/toolbelt/date_test.clj
+++ b/test/toolbelt/date_test.clj
@@ -98,14 +98,21 @@
            (date/plus date (date/period :millis 100))))))
 
 
+;; =============================================================================
+;; Property based
+;; =============================================================================
+
+
+(defn- gen-date* []
+  (gen/fmap (fn [n] (c/to-date n)) gen/int))
+
+
 (defspec date-plus-minus-test
   100
   (prop/for-all
-    [year (gen/double* {:min 1 :max 3000 :NaN? false})
-     month (gen/double* {:min 1 :max 12 :NaN? false})
+    [inst (gen-date*)
      p gen/pos-int]
-    (let [date-time (t/date-time (int year) (int month))
-          inst      (c/to-date date-time)
+    (let [date-time (c/to-date-time inst)
           days      (t/days p)]
       (testing "The inst plus a period is always equal that inst minus the same period."
         (are [d2] (= inst d2)
@@ -116,5 +123,17 @@
           (-> (date/plus inst days)
               (date/minus days))
           ;; Long (unix time)
-          (-> (date/plus (c/to-long date-time) days)
+          (-> (date/plus (c/to-long inst) days)
               (date/minus days)))))))
+
+
+(defspec date-min-max-test
+  100
+  (prop/for-all
+    [dts (gen/vector (gen-date*) 1 100)]
+    (testing "Min date is always the earliest and max date is always the latest."
+      (let [sorted-dates (sort dts)]
+        (is (= (apply date/max dts) (last sorted-dates))
+            "Max date should be the latest date.")
+        (is (= (apply date/min dts) (first sorted-dates))
+            "Min date should be the earliest date.")))))


### PR DESCRIPTION
## Context
Adding min/max functions for dates to easier find latest or earliest date of the supplied date. Especially useful in https://github.com/starcity-properties/blueprints/pull/141.

**Other**
I changed the repository to our own starjars so we can release/deploy and change it to our needs. I don't think this needs to be in clojars, since there is already `clj-time` and `java-time` available which are much more extensive. This library does not provide enough functionality to be used without one of the above anyway.